### PR TITLE
Node version change

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "eslint": "^8.9.0",
     "eslint-plugin-jsdoc": "^37.9.4",
-    "node": "^16.10.0",
+    "node": "^16.16.0",
     "nodemon": "^2.0.15",
     "prettier": "2.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Sai Teja M",
   "license": "ISC",
   "engines": {
-    "node": ">=16.6.0"
+    "node": "16.16.0"
   },
   "scripts": {
     "dev": "nodemon .",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "eslint": "^8.9.0",
     "eslint-plugin-jsdoc": "^37.9.4",
-    "node": "^16.16.0",
+    "node": "16.16.0",
     "nodemon": "^2.0.15",
     "prettier": "2.5.1"
   },


### PR DESCRIPTION
Node version v16.10.0 to 16.16.0 for erela.js

Before: 
![image](https://user-images.githubusercontent.com/69589887/183266776-259a9971-25dc-4a26-bb54-bc54accbd0dd.png)
![image](https://user-images.githubusercontent.com/69589887/183266781-8a7f5c6c-60ba-4d17-b746-453e6768f0f6.png)

After: 
![image](https://user-images.githubusercontent.com/69589887/183266792-2145a156-c1d4-4c9d-89a1-06d9f6c00821.png)
