### PR TITLE
Refactor anti command

### DIFF
--- a/src/commands/admin/automod/anti.js
+++ b/src/commands/admin/automod/anti.js
@@ -1,11 +1,11 @@
-const { ApplicationCommandOptionType } = require("discord.js");
+const { ApplicationCommandOptionType, SelectMenuBuilder, ActionRowBuilder, EmbedBuilder, ButtonBuilder, ModalBuilder, TextInputBuilder, InteractionCollector } = require("discord.js");
 
 /**
  * @type {import("@structures/Command")}
  */
 module.exports = {
-  name: "anti",
-  description: "manage various automod settings for the server",
+  name: "antiautomod",
+  description: "Manage various automod settings for the server",
   category: "AUTOMOD",
   userPermissions: ["ManageGuild"],
   command: {
@@ -29,83 +29,7 @@ module.exports = {
   slashCommand: {
     enabled: true,
     ephemeral: true,
-    options: [
-      {
-        name: "ghostping",
-        description: "detects and logs ghost mentions in your server",
-        type: ApplicationCommandOptionType.Subcommand,
-        options: [
-          {
-            name: "status",
-            description: "configuration status",
-            required: true,
-            type: ApplicationCommandOptionType.String,
-            choices: [
-              {
-                name: "ON",
-                value: "ON",
-              },
-              {
-                name: "OFF",
-                value: "OFF",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        name: "spam",
-        description: "enable or disable antispam detection",
-        type: ApplicationCommandOptionType.Subcommand,
-        options: [
-          {
-            name: "status",
-            description: "configuration status",
-            required: true,
-            type: ApplicationCommandOptionType.String,
-            choices: [
-              {
-                name: "ON",
-                value: "ON",
-              },
-              {
-                name: "OFF",
-                value: "OFF",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        name: "massmention",
-        description: "enable or disable massmention detection",
-        type: ApplicationCommandOptionType.Subcommand,
-        options: [
-          {
-            name: "status",
-            description: "configuration status",
-            required: true,
-            type: ApplicationCommandOptionType.String,
-            choices: [
-              {
-                name: "ON",
-                value: "ON",
-              },
-              {
-                name: "OFF",
-                value: "OFF",
-              },
-            ],
-          },
-          {
-            name: "threshold",
-            description: "configuration threshold (default is 3 mentions)",
-            required: false,
-            type: ApplicationCommandOptionType.Integer,
-          },
-        ],
-      },
-    ],
+    options: [],
   },
 
   async messageRun(message, args, data) {
@@ -140,45 +64,124 @@ module.exports = {
   },
 
   async interactionRun(interaction, data) {
-    const sub = interaction.options.getSubcommand();
     const settings = data.settings;
+    let select = new SelectMenuBuilder()
+    .setCustomId("select")
+    .setPlaceholder("Select module")
+    .setOptions({
+      label: "Ghost ping",
+      description: "Detects and logs ghost mentions in your server",
+      value: "ghostping"
+    }, {
+      label: "Spam",
+      description: "Enable or disable antispam detection",
+      value: "spam"
+    }, {
+      label: "Mass mention",
+      description: "Enable or disable massmention detection",
+      value: "massmention"
+    })
+    let selectrow = new ActionRowBuilder().addComponents(select)
+    let response = await interaction.editReply({components: [selectrow]})
 
-    let response;
-    if (sub == "ghostping") response = await antiGhostPing(settings, interaction.options.getString("status"));
-    else if (sub == "spam") response = await antiSpam(settings, interaction.options.getString("status"));
-    else if (sub === "massmention") {
-      response = await antiMassMention(
-        settings,
-        interaction.options.getString("status"),
-        interaction.options.getInteger("amount")
-      );
-    } else response = "Invalid command usage!";
+    let collector = response.createMessageComponentCollector({type: 4})
+    collector.on("collect", async i => {
+      if(i.customId != "select") return;
+      if(i.values[0] == "ghostping") ghostPing()
+      if(i.values[0] == "spam") spam()
+      if(i.values[0] == "massmention") massMention()
+      i.deferUpdate()
+    })
 
-    await interaction.followUp(response);
+    let ghostcollector = response.createMessageComponentCollector({type: 3})
+    ghostcollector.on("collect", async statusi => {
+      if(statusi.customId != "status_ghostping") return;
+      settings.automod.anti_ghostping = settings.automod.anti_ghostping ? false : true
+      await settings.save()
+      ghostPing()
+      statusi.deferUpdate()
+    })
+
+    let spamcollector = response.createMessageComponentCollector({type: 3})
+    spamcollector.on("collect", async statusi => {
+      if(statusi.customId != "status_spam") return
+      settings.automod.anti_spam = settings.automod.anti_spam ? false: true
+      await settings.save()
+      spam()
+      statusi.deferUpdate()
+    })
+
+    let mentioncollector = response.createMessageComponentCollector({type: 3})
+    mentioncollector.on("collect", async statusi => {
+      if(statusi.customId == "status_massmention") {
+        settings.automod.anti_massmention = settings.automod.anti_massmention ? 0 : 3
+        await settings.save()
+        massMention()
+        statusi.deferUpdate()
+      } else if(statusi.customId == "threshold") {
+        let modal = new ModalBuilder()
+        .setCustomId("modal" + statusi.id)
+        .setTitle("Set threshold");
+        let threshold = new TextInputBuilder()
+        .setCustomId('threshold')
+        .setLabel("Threshold")
+        .setStyle("Short");
+        let row = new ActionRowBuilder().addComponents(threshold);
+        modal.addComponents(row);
+        await statusi.showModal(modal);
+        let collectorm = new InteractionCollector(interaction.client)
+        collectorm.on("collect", async res => {
+          if(res.customId != "modal" + statusi.id) return;
+          if(isNaN(res.fields.getTextInputValue('threshold'))) return res.reply({ephemeral: true, content: "Not an number"})
+          if(Number(res.fields.getTextInputValue('threshold')) < 1) return res.reply({ephemeral: true, content: "Insert a number higher than 1"})
+          settings.automod.anti_massmention = Number(res.fields.getTextInputValue('threshold'))
+          await settings.save()
+          massMention()
+          res.deferUpdate()
+        })
+      }
+    })
+
+    function ghostPing() {
+      let embed = new EmbedBuilder()
+      .setTitle("Ghost ping")
+      .setFields({name: "Status", value: settings.automod.anti_ghostping ? "ON" : "OFF"})
+      let button = new ButtonBuilder()
+      .setCustomId("status_ghostping")
+      .setLabel(settings.automod.anti_ghostping ? "Disable" : "Enable")
+      .setStyle(settings.automod.anti_ghostping ? "Danger" : "Success")
+      let buttonrow = new ActionRowBuilder().addComponents(button)
+      interaction.editReply({components: [buttonrow, selectrow], embeds: [embed]})
+    }
+    
+    function spam() {
+      let embed = new EmbedBuilder()
+        .setTitle("Spam")
+        .setFields({name: "Status", value: settings.automod.anti_spam ? "ON" : "OFF"})
+        let button = new ButtonBuilder()
+        .setCustomId("status_spam")
+        .setLabel(settings.automod.anti_spam ? "Disable" : "Enable")
+        .setStyle(settings.automod.anti_spam ? "Danger" : "Success")
+        let buttonrow = new ActionRowBuilder().addComponents(button)
+        interaction.editReply({components: [buttonrow, selectrow], embeds: [embed]})
+    }
+
+    function massMention() {
+      let embed = new EmbedBuilder()
+        .setTitle("Mass mention")
+        .setFields({name: "Status", value: settings.automod.anti_massmention ? "ON" : "OFF"})
+        if(settings.automod.anti_massmention) embed.addFields({name: "Threshold", value: settings.automod.anti_massmention.toString()})
+        let button = new ButtonBuilder()
+        .setCustomId("status_massmention")
+        .setLabel(settings.automod.anti_massmention ? "Disable" : "Enable")
+        .setStyle(settings.automod.anti_massmention ? "Danger" : "Success")
+        let button2 = new ButtonBuilder()
+        .setCustomId("threshold")
+        .setLabel("Set threshold")
+        .setStyle("Primary")
+        .setDisabled(settings.automod.anti_massmention ? false : true)
+        let buttonrow = new ActionRowBuilder().addComponents(button, button2)
+        interaction.editReply({components: [buttonrow, selectrow], embeds: [embed]})
+    }
   },
 };
-
-async function antiGhostPing(settings, input) {
-  const status = input.toUpperCase() === "ON" ? true : false;
-  settings.automod.anti_ghostping = status;
-  await settings.save();
-  return `Configuration saved! Anti-Ghostping is now ${status ? "enabled" : "disabled"}`;
-}
-
-async function antiSpam(settings, input) {
-  const status = input.toUpperCase() === "ON" ? true : false;
-  settings.automod.anti_spam = status;
-  await settings.save();
-  return `Antispam detection is now ${status ? "enabled" : "disabled"}`;
-}
-
-async function antiMassMention(settings, input, threshold) {
-  const status = input.toUpperCase() === "ON" ? true : false;
-  if (!status) {
-    settings.automod.anti_massmention = 0;
-  } else {
-    settings.automod.anti_massmention = threshold;
-  }
-  await settings.save();
-  return `Mass mention detection is now ${status ? "enabled" : "disabled"}`;
-}


### PR DESCRIPTION
`/anti ghostping`, `/anti spam` and `/anti massmention` are now with a select menu, a modal and some buttons, the user can disable and enable the modules and set the threshold of massmention just with them.
I don't which name use for the command btw
![image](https://user-images.githubusercontent.com/75396448/201550925-b1476646-fe01-488a-a632-05656d824aae.png)