### PR TITLE
create collector in message only

### DIFF
--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -137,7 +137,7 @@ async function getHelpMenu({ client, guild }) {
  * @param {string} prefix
  */
 const waiter = (msg, userId, prefix) => {
-  const collector = msg.channel.createMessageComponentCollector({
+  const collector = msg.createMessageComponentCollector({
     filter: (reactor) => reactor.user.id === userId && msg.id === reactor.message.id,
     idle: IDLE_TIMEOUT * 1000,
     dispose: true,


### PR DESCRIPTION
Improvement suggestion: If you are waiting for button or select menu input from a specific message, you shouldn't create the collector on the channel.
```diff
- <Channel>.createMessageComponentCollector(…)
+ <Message>.createMessageComponentCollector(…)
``` 
Channel collectors return component interactions for any component within that channel which may cause a problem
But since filter basically already includes that check so we've never faced a problem before

but that doesn't mean we can keep it on channel instead of message only