### PR TITLE
"Tickets" channel category

### DIFF
--- a/src/commands/ticket/ticket.js
+++ b/src/commands/ticket/ticket.js
@@ -338,6 +338,20 @@ async function ticketModalSetup({ guild, channel, member }, targetChannel, setti
   const description = modal.fields.getTextInputValue("description");
   const footer = modal.fields.getTextInputValue("footer");
 
+  // create ticket channel category
+  if (!guild.channels.cache.find((ch) => ch.name === "Tickets" && ch.type === ChannelType.GuildCategory)) {
+    guild.channels.create({
+      name: "Tickets",
+      type: ChannelType.GuildCategory,
+      permissionsOverwrites: [
+        {
+          id: guild.roles.everyone,
+          deny: ["ViewChannel", "SendMessages", "ReadMessageHistory"],
+        },
+      ],
+    });
+  }
+
   // send ticket message
   const embed = new EmbedBuilder()
     .setColor(EMBED_COLORS.BOT_EMBED)

--- a/src/handlers/ticket.js
+++ b/src/handlers/ticket.js
@@ -233,8 +233,12 @@ async function handleTicketOpen(interaction) {
       });
     }
 
+    // get channel parent ("Tickets" category)
+    const parent = guild.channels.cache.find((ch) => ch.name === "Tickets" && ch.type === ChannelType.GuildCategory);
+
     const tktChannel = await guild.channels.create({
       name: `tіcket-${ticketNumber}`,
+      parent: parent?.id,
       type: ChannelType.GuildText,
       topic: `tіcket|${user.id}|${catName || "Default"}`,
       permissionOverwrites,


### PR DESCRIPTION
This change will create a "Tickets" channel category when a user is running the `/ticket setup` command. Once complete, all new tickets will be created under said category instead of at the top of the channel list. 

This idea originated from my own version of this bot alongside issue #362 