### PR TITLE
Fix /help: Cannot read properties of undefined (reading 'find')

### DIFF
--- a/src/handlers/command.js
+++ b/src/handlers/command.js
@@ -178,7 +178,7 @@ module.exports = {
    */
   getSlashUsage(cmd) {
     let desc = "";
-    if (cmd.slashCommand.options.find((o) => o.type === ApplicationCommandOptionType.Subcommand)) {
+    if (cmd.slashCommand.options?.find((o) => o.type === ApplicationCommandOptionType.Subcommand)) {
       const subCmds = cmd.slashCommand.options.filter((opt) => opt.type === ApplicationCommandOptionType.Subcommand);
       subCmds.forEach((sub) => {
         desc += `\`/${cmd.name} ${sub.name}\`\n❯ ${sub.description}\n\n`;


### PR DESCRIPTION
Bug found in: slash help command
When you search a commands with no options/sub commands bot returns an error:
`ERROR: interactionRun: modalResponse.reply is not a function` because of the unhandled exeption (when there's no opts)
So I made it optional so in case options doesn't exist it skips finding options
btw, all bot's have this issue
![image](https://github.com/saiteja-madha/discord-js-bot/assets/43763935/5b4f26c0-ce0f-48ac-a85d-7ffb58270e77)
![image](https://github.com/saiteja-madha/discord-js-bot/assets/43763935/10a01432-3da5-4873-955c-af3b14aa102e)
