### PR TITLE
Fix Purge command

### DIFF
--- a/src/commands/moderation/slash/purge.js
+++ b/src/commands/moderation/slash/purge.js
@@ -186,7 +186,7 @@ module.exports = {
 
       case "user": {
         const user = interaction.options.getUser("user");
-        response = await purgeMessages(member, channel, "USER", amount, user);
+        response = await purgeMessages(member, channel, "USER", amount, user.id);
         break;
       }
 

--- a/src/helpers/ModUtils.js
+++ b/src/helpers/ModUtils.js
@@ -178,7 +178,38 @@ module.exports = class ModUtils {
     const toDelete = new Collection();
 
     try {
-      const messages = await channel.messages.fetch({ limit: amount, cache: false, force: true });
+      let messages;
+      switch(type) {
+        case "ALL":
+          messages = await channel.messages.fetch({ limit: amount, cache: false, force: true });
+          break;
+        case "BOT": {
+          messages = await channel.messages.fetch({cache: false, force: true });
+          messages = messages.filter(message => message.author.bot).first(amount);
+          break;
+        }
+        case "LINK": {
+          messages = await channel.messages.fetch({cache: false, force: true });
+          messages = messages.filter(message => containsLink(message.content)).first(amount);
+          break;
+        }
+        case "TOKEN": {
+          messages = await channel.messages.fetch({cache: false, force: true });
+          messages = messages.filter(message => message.content.includes(argument)).first(amount);
+          break;
+        }
+        case "ATTACHMENT": {
+          messages = await channel.messages.fetch({cache: false, force: true });
+          messages = messages.filter(message => message.attachments.size > 0).first(amount);
+          break;
+        }
+        case "USER": {
+          messages = await channel.messages.fetch({cache: false, force: true });
+          messages = messages.filter(message => message.author.id === argument).first(amount);
+          console.log(messages)
+          break;
+        }
+      }
 
       for (const message of messages.values()) {
         if (toDelete.size >= amount) break;

--- a/src/helpers/ModUtils.js
+++ b/src/helpers/ModUtils.js
@@ -206,7 +206,6 @@ module.exports = class ModUtils {
         case "USER": {
           messages = await channel.messages.fetch({cache: false, force: true });
           messages = messages.filter(message => message.author.id === argument).first(amount);
-          console.log(messages)
           break;
         }
       }


### PR DESCRIPTION
### Issue Description:

1. **purge user command:** this command was passing the whole user meanwhile purgeMessages() function requires only the ID (which also causes a problem to return 0 found messages due to false condition)
2. **purge types (excluding "ALL") isn't working properly:** it was taking last "amount" messages sent in channel and delete the element which achieves one of the purge types condition
but it doesn't delete everything correctly sometimes when messages are mixed
so this one takes all messages and fiter amount of them

### Solution

- [x] Pass user.id only instead of whole user object (best practice, more faster because funcion only uses the id)
- [x] we let bot to fetch all sent messages then we fiter last "amount" of "TYPE" sent messages