### PR TITLE
Fix contexts count always 0

### DIFF
--- a/src/structures/BotClient.js
+++ b/src/structures/BotClient.js
@@ -209,8 +209,8 @@ module.exports = class BotClient extends Client {
       }
     }
 
-    const userContexts = this.contextMenus.filter((ctx) => ctx.type === "USER").size;
-    const messageContexts = this.contextMenus.filter((ctx) => ctx.type === "MESSAGE").size;
+    const userContexts = this.contextMenus.filter((ctx) => ctx.type === ApplicationCommandType.User).size;
+    const messageContexts = this.contextMenus.filter((ctx) => ctx.type === ApplicationCommandType.Message).size;
 
     if (userContexts > 3) throw new Error("A maximum of 3 USER contexts can be enabled");
     if (messageContexts > 3) throw new Error("A maximum of 3 MESSAGE contexts can be enabled");


### PR DESCRIPTION
actuall code still using "MESSAGE" and "USER" to filter context types which is from Discord.js v13
So we use `ApplicationCommandType` enum from Discord.js v14