### PR TITLE
Fix /search bug: select menu options must be >= 1

### DIFF
--- a/src/commands/music/search.js
+++ b/src/commands/music/search.js
@@ -81,7 +81,8 @@ async function search({ member, guild, channel }, query) {
   let embed = new EmbedBuilder().setColor(EMBED_COLORS.BOT_EMBED);
   let tracks;
 
-  switch (res.loadType) {
+  const loadType = res.tracks.length > 0 ? res.loadType : "NO_MATCHES
+  switch (loadType) {
     case "LOAD_FAILED":
       guild.client.logger.error("Search Exception", res.exception);
       return "🚫 There was an error while searching";


### PR DESCRIPTION
`res.loadType` is somehow returning `SEARCH_RESULT` even when there's no results found matching the search query, which gives the string select menu 0 options to add and that causes an unhandled error:
```js
DiscordAPIError[50035]: Invalid Form Body
components[0].components[0].max_values[NUMBER_TYPE_MIN]: int value should be greater than or equal to 1.
components[0].components[0].options[BASE_TYPE_BAD_LENGTH]: Must be between 1 and 25 in length.
```