### PR TITLE
Fix move command "No matching channels found"

### DIFF
--- a/src/commands/moderation/message/move.js
+++ b/src/commands/moderation/message/move.js
@@ -20,7 +20,7 @@ module.exports = {
     const target = await message.guild.resolveMember(args[0], true);
     if (!target) return message.safeReply(`No user found matching ${args[0]}`);
 
-    const channels = message.guild.findMatchingChannels(args[1]);
+    const channels = message.guild.findMatchingVoiceChannels(args[1]);
     if (!channels.length) return message.safeReply("No matching channels found");
     const targetChannel = channels.pop();
     if (!targetChannel.type === ChannelType.GuildVoice && !targetChannel.type === ChannelType.GuildStageVoice) {

--- a/src/helpers/extenders/Guild.js
+++ b/src/helpers/extenders/Guild.js
@@ -9,7 +9,40 @@ const MEMBER_MENTION = /<?@?!?(\d{17,20})>?/;
  * @param {string} query
  * @param {import("discord.js").GuildChannelTypes[]} type
  */
-Guild.prototype.findMatchingChannels = function (query, type = [ChannelType.GuildText, ChannelType.GuildNews]) {
+Guild.prototype.findMatchingChannels = function (query, type = [ChannelType.GuildText, ChannelType.GuildAnnouncement]) {
+  if (!this || !query || typeof query !== "string") return [];
+
+  const channelManager = this.channels.cache.filter((ch) => type.includes(ch.type));
+
+  const patternMatch = query.match(CHANNEL_MENTION);
+  if (patternMatch) {
+    const id = patternMatch[1];
+    const channel = channelManager.find((r) => r.id === id);
+    if (channel) return [channel];
+  }
+
+  const exact = [];
+  const startsWith = [];
+  const includes = [];
+  channelManager.forEach((ch) => {
+    const lowerName = ch.name.toLowerCase();
+    if (ch.name === query) exact.push(ch);
+    if (lowerName.startsWith(query.toLowerCase())) startsWith.push(ch);
+    if (lowerName.includes(query.toLowerCase())) includes.push(ch);
+  });
+
+  if (exact.length > 0) return exact;
+  if (startsWith.length > 0) return startsWith;
+  if (includes.length > 0) return includes;
+  return [];
+};
+
+/**
+ * Get all channels that match the query
+ * @param {string} query
+ * @param {import("discord.js").GuildChannelTypes[]} type
+ */
+Guild.prototype.findMatchingVoiceChannels = function (query, type = [ChannelType.GuildVoice, ChannelType.GuildStageVoice]) {
   if (!this || !query || typeof query !== "string") return [];
 
   const channelManager = this.channels.cache.filter((ch) => type.includes(ch.type));


### PR DESCRIPTION
### Bug Description: 
In all the ways bot returns "No matching channels found" error even if the voice channel exists

### Bug Cause: 
the cause is using the custom Guild method `findMatchingChannels` which only supports text channels.

### Solution: 
so I added another method called `findMatchingVoiceChannels` that can find voice channels too without touching the first to not break any functionality with other commands

### Pull Request recap:
- [x] Changed ChannelType.GuildNews (which is deprecated now) with ChannelType.GuildAnnouncement
- [x] Added new method to `Guild` called `findMatchingVoiceChannels` that find voice channels starting from a channel mention
- [x] Pointed the move command to the new method