### PR TITLE
[Feature] Adds a voice channel status with the currently playing song title!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@lavaclient/spotify": "^3.1.0",
         "@vitalets/google-translate-api": "^9.2.0",
         "ascii-table": "0.0.9",
+        "axios": "^1.6.7",
         "btoa": "^1.2.1",
         "common-tags": "^1.8.2",
         "connect-mongo": "^5.1.0",
@@ -1986,6 +1987,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2554,6 +2565,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/erlpack/-/erlpack-0.1.4.tgz",
       "integrity": "sha512-CJYbkEvsB5FqCCu2tLxF1eYKi28PvemC12oqzJ9oO6mDFrFO9G9G7nNJUHhiAyyL9zfXTOJx/tOcrQk+ncD65w==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3122,6 +3134,25 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -4400,6 +4431,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -5463,6 +5499,7 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.9.tgz",
       "integrity": "sha512-DinB43xCjVwIBDpaIvQqHbmDsnYnSt6HJ/yiB2MZQGTqgPcwBSZqLkimXwK8BvdjQ/MaZysb5uEenImncqvCqQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@lavaclient/spotify": "^3.1.0",
     "@vitalets/google-translate-api": "^9.2.0",
     "ascii-table": "0.0.9",
-    "axios": "^1.6.7",
     "btoa": "^1.2.1",
     "common-tags": "^1.8.2",
     "connect-mongo": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@lavaclient/spotify": "^3.1.0",
     "@vitalets/google-translate-api": "^9.2.0",
     "ascii-table": "0.0.9",
+    "axios": "^1.6.7",
     "btoa": "^1.2.1",
     "common-tags": "^1.8.2",
     "connect-mongo": "^5.1.0",

--- a/src/commands/music/pause.js
+++ b/src/commands/music/pause.js
@@ -34,7 +34,7 @@ function pause({ client, guildId }) {
   if (player.paused) return "The player is already paused.";
 
   player.pause(true);
-  // emiting a new event 'playerPaused' to handle voice channel status reset
+  // emiting a new event 'playerPaused' to handle voice channel status update
   client.musicManager.emit('playerPaused', player, player.trackData)
   return "⏸️ Paused the music player.";
 }

--- a/src/commands/music/pause.js
+++ b/src/commands/music/pause.js
@@ -34,5 +34,7 @@ function pause({ client, guildId }) {
   if (player.paused) return "The player is already paused.";
 
   player.pause(true);
+  // emiting a new event 'playerPaused' to handle voice channel status reset
+  client.musicManager.emit('playerPaused', player, player.trackData)
   return "⏸️ Paused the music player.";
 }

--- a/src/commands/music/resume.js
+++ b/src/commands/music/resume.js
@@ -34,7 +34,7 @@ function resumePlayer({ client, guildId }) {
   if (!player.paused) return "The player is already resumed";
   player.resume();
 
-  // emiting a new event 'playerResume' to handle voice channel status reset
+  // emiting a new event 'playerResume' to handle voice channel status update
   client.musicManager.emit('playerResumed', player, player.trackData)
   return "▶️ Resumed the music player";
 }

--- a/src/commands/music/resume.js
+++ b/src/commands/music/resume.js
@@ -33,5 +33,8 @@ function resumePlayer({ client, guildId }) {
   const player = client.musicManager.getPlayer(guildId);
   if (!player.paused) return "The player is already resumed";
   player.resume();
+
+  // emiting a new event 'playerResume' to handle voice channel status reset
+  client.musicManager.emit('playerResumed', player, player.trackData)
   return "▶️ Resumed the music player";
 }

--- a/src/commands/music/stop.js
+++ b/src/commands/music/stop.js
@@ -34,5 +34,8 @@ async function stop({ client, guildId }) {
   const player = client.musicManager.getPlayer(guildId);
   player.disconnect();
   await client.musicManager.destroyPlayer(guildId);
+
+  // emiting a new event 'playerDestroy' to handle voice channel status reset
+  client.musicManager.emit('playerDestroy', player)
   return "🎶 The music player is stopped and queue has been cleared";
 }

--- a/src/handlers/lavaclient.js
+++ b/src/handlers/lavaclient.js
@@ -85,32 +85,34 @@ module.exports = (client) => {
     // reset voice channel's status
     await updateVoiceStatus(queue.player.channelId, '', client)
   });
-  
+
   // for when player is paused, indicate 'paused' in the status
-  lavaclient.on('playerPaused', async (player, song) => {  
-    await updateVoiceStatus(player.channelId, `Paused **${song.title}**`, client) 
+  lavaclient.on('playerPaused', async (player, song) => {
+    await updateVoiceStatus(player.channelId, `Paused **${song.title}**`, client)
   })
   // for when player is resumed, indicate 'playing' in the status
-  lavaclient.on('playerResumed', async (player, song) => { 
-    await updateVoiceStatus(player.channelId, `Playing **${song.title}**`, client)     
+  lavaclient.on('playerResumed', async (player, song) => {
+    await updateVoiceStatus(player.channelId, `Playing **${song.title}**`, client)
   })
   // for when player is stopped, reset the status
   lavaclient.on('playerDestroy', async (player) => {
-    await updateVoiceStatus(player.channelId, '', client)     
+    await updateVoiceStatus(player.channelId, '', client)
   })
   return lavaclient;
 };
 
-
+/**
+ * 
+ * @param {string} channel The channel Id to update the status
+ * @param {string} status The status
+ * @param {import("discord.js").Client} client Bot's client
+ */
 async function updateVoiceStatus(channel, status, client) {
   const url = `/channels/${channel}/voice-status`;
-  const payload = {
-    status: status
-  };
   await client.rest.put(url, {
     body: {
       status: status
-   }
+    }
   })
-    .catch(() => {});
+    .catch(() => { });
 }

--- a/src/handlers/lavaclient.js
+++ b/src/handlers/lavaclient.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require("discord.js");
 const { Cluster } = require("lavaclient");
-const axios = require("axios");
 const prettyMs = require("pretty-ms");
 const { load, SpotifyItemType } = require("@lavaclient/spotify");
 require("@lavaclient/queue/register");

--- a/src/handlers/lavaclient.js
+++ b/src/handlers/lavaclient.js
@@ -103,7 +103,7 @@ module.exports = (client) => {
 };
 
 
-async function updateVoiceStatus(channel, status) {
+async function updateVoiceStatus(channel, status, client) {
   const url = `/channels/${channel}/voice-status`;
   const payload = {
     status: status

--- a/src/handlers/lavaclient.js
+++ b/src/handlers/lavaclient.js
@@ -76,7 +76,7 @@ module.exports = (client) => {
 
     // update voice channel status with 'Now Playing'
     await client.wait(1000) // waiting 1 sec, because channel id is null initially
-    await updateVoiceStatus(queue.player.channelId, `Playing **${song.title}**`)
+    await updateVoiceStatus(queue.player.channelId, `Playing **${song.title}**`, client)
   });
 
   lavaclient.on("nodeQueueFinish", async (_node, queue) => {
@@ -84,36 +84,34 @@ module.exports = (client) => {
     await client.musicManager.destroyPlayer(queue.player.guildId).then(queue.player.disconnect());
 
     // reset voice channel's status
-    await updateVoiceStatus(queue.player.channelId, '')
+    await updateVoiceStatus(queue.player.channelId, '', client)
   });
   
   // for when player is paused, indicate 'paused' in the status
   lavaclient.on('playerPaused', async (player, song) => {  
-    await updateVoiceStatus(player.channelId, `Paused **${song.title}**`) 
+    await updateVoiceStatus(player.channelId, `Paused **${song.title}**`, client) 
   })
   // for when player is resumed, indicate 'playing' in the status
   lavaclient.on('playerResumed', async (player, song) => { 
-    await updateVoiceStatus(player.channelId, `Playing **${song.title}**`)     
+    await updateVoiceStatus(player.channelId, `Playing **${song.title}**`, client)     
   })
   // for when player is stopped, reset the status
   lavaclient.on('playerDestroy', async (player) => {
-    await updateVoiceStatus(player.channelId, '')     
+    await updateVoiceStatus(player.channelId, '', client)     
   })
   return lavaclient;
 };
 
 
 async function updateVoiceStatus(channel, status) {
-  const url = `https://discord.com/api/v10/channels/${channel}/voice-status`;
+  const url = `/channels/${channel}/voice-status`;
   const payload = {
     status: status
   };
-  axios.put(url, payload, {
-    headers: {
-      Authorization: `Bot ${process.env.BOT_TOKEN}`
-    }
+  await client.rest.put(url, {
+    body: {
+      status: status
+   }
   })
-    .catch(error => {
-      console.error('Error updating VC status:', error.response ? error.response.data : error.message);
-    });
+    .catch(() => {});
 }


### PR DESCRIPTION
Features added!

- Updates the voice channel status with song title when player starts
- Resets it when player is stopped or queue ends
- Shows 'Paused' when player is paused and 'Playing' when resumed
- See attachments for references
_Voice channel status is only available on desktop clients, and bot needs 'Set Voice Channel Status' permission to perform these actions, it can also be edited by anyone with the permission, so they could change it to something else after the bot_
See relevant Discord API PR About this feature:- [discord/discord-api-docs#6400](https://github.com/discord/discord-api-docs/pull/6400)


Changes are commented in each respective file.
I couldn't find some events in the lavaclient docs necessary for some of the features so I emitted custom events where applicable

**This endpoint is undocumented and experimental and as such not possible through discord.js (yet). As it is undocumented, it may also be unstable**

Please feel free to edit to improve or fix as you see fit.
![Screenshot (78)](https://github.com/saiteja-madha/discord-js-bot/assets/137700126/9ee46b23-2a37-4a4c-99bb-ce2fbd744f5a)
![Screenshot (80)](https://github.com/saiteja-madha/discord-js-bot/assets/137700126/9d546943-b437-4366-98dd-9af303a70e6b)

## Checklist

- [ ] Tested Locally
- [ ] Extensive Testing
- [x] No Conflicts
- [x] No Errors
- [ ] Stable