### PR TITLE
Prevent bot from generating NSFW content using /meme command

### DIFF
--- a/src/commands/fun/meme.js
+++ b/src/commands/fun/meme.js
@@ -135,7 +135,9 @@ async function getRandomEmbed(choice) {
     let memeUpvotes = json[0].data.children[0].data.ups;
     let memeNumComments = json[0].data.children[0].data.num_comments;
 
-    return new EmbedBuilder()
+    return (json[0].data.children[0].data.over_18 && !context.channel.nsfw) ?
+    new EmbedBuilder().setColor("Red").setTitle("Unable to send meme").setDescription("It appears that you've used a subreddit that may contain NSFW content.") :
+    new EmbedBuilder()
       .setAuthor({ name: memeTitle, url: memeUrl })
       .setImage(memeImage)
       .setColor("Random")


### PR DESCRIPTION
This pull request will prevent bot from generating NSFW content using /meme command by passing a NSFW based subreddit

Big thanks to @Twinkle069 for finding this problem