### PR TITLE
Fix to handle async codes in eval

### DIFF
--- a/src/commands/owner/eval.js
+++ b/src/commands/owner/eval.js
@@ -36,7 +36,7 @@ module.exports = {
 
     let response;
     try {
-      const output = eval(input);
+      const output = await eval(input);
       response = buildSuccessResponse(output, message.client);
     } catch (ex) {
       response = buildErrorResponse(ex);
@@ -49,7 +49,7 @@ module.exports = {
 
     let response;
     try {
-      const output = eval(input);
+      const output = await eval(input);
       response = buildSuccessResponse(output, interaction.client);
     } catch (ex) {
       response = buildErrorResponse(ex);


### PR DESCRIPTION
Instead of output being `Promise { <pending> }`, it'll wait for async functions to resolve first