### PR TITLE
Fix search.js

### DIFF
--- a/src/commands/music/search.js
+++ b/src/commands/music/search.js
@@ -154,7 +154,7 @@ async function search({ member, guild, channel }, query) {
 
       const results = res.tracks.slice(0, max);
       const options = results.map((result, index) => ({
-        label: result.info.title,
+        label: result.info.title.length > 100 ? result.info.title.slice(0, 97) + '...' : result.info.title, // Truncate title
         value: index.toString(),
       }));
 


### PR DESCRIPTION
If your search result is more than 100 characters then it throws error. [So now it converts last three char to ...]