### PR TITLE
fix: incorrect comparisons

### DIFF
--- a/src/helpers/extenders/GuildChannel.js
+++ b/src/helpers/extenders/GuildChannel.js
@@ -14,9 +14,11 @@ GuildChannel.prototype.canSendEmbeds = function () {
  */
 GuildChannel.prototype.safeSend = async function (content, seconds) {
   if (!content) return;
-  if (!this.type === ChannelType.GuildText && !this.type === ChannelType.DM) return;
+  if (this.type !== ChannelType.GuildText && this.type !== ChannelType.DM && this.type !== ChannelType.GuildVoice) return;
 
   const perms = ["ViewChannel", "SendMessages"];
+  if (this.type === ChannelType.GuildVoice) perms.push("Connect");
+
   if (content.embeds && content.embeds.length > 0) perms.push("EmbedLinks");
   if (!this.permissionsFor(this.guild.members.me).has(perms)) return;
 


### PR DESCRIPTION
The comparison here is simply incorrect 
https://github.com/saiteja-madha/discord-js-bot/blob/34a1631bbcb2ee73ed89ce98a9ff84b4d680d4da/src/helpers/extenders/GuildChannel.js#L17
You are using `!` against a `number` (channel type) which will get coerced to a boolean and `boolean === number` will never be true.

Also included voice channel here since you can send a message in a voice channel (and needs `Connect` Permissions to send messages as part of implicit permissions)