### PR TITLE
Strange API replaced URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ SESSION_PASSWORD=
 # Required for Weather Command (https://weatherstack.com)
 WEATHERSTACK_KEY=
 
-# Required for image commands (https://strangeapi.fun/docs)
+# Required for image commands (https://strangeapi.hostz.me/)
 STRANGE_API_KEY=
 
 # SPOTFIY [Required for Spotify Support]


### PR DESCRIPTION
strangeapi.fun is down since many time.
https://strangeapi.hostz.me/ seems to be the new url.

do wathever you want with this pr.