### PR TITLE
Add cluster sharding with discord-hybrid-sharding

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,8 @@
 require("dotenv").config();
 require("module-alias/register");
 
+const { ClusterClient, getInfo } = require("discord-hybrid-sharding");
+
 // register extenders
 require("@helpers/extenders/Message");
 require("@helpers/extenders/Guild");
@@ -13,11 +15,29 @@ const { validateConfiguration } = require("@helpers/Validator");
 
 validateConfiguration();
 
-// initialize client
-const client = new BotClient();
+// initialize client with shard info from manager
+const client = new BotClient({
+  shards: getInfo().SHARD_LIST,
+  shardCount: getInfo().TOTAL_SHARDS,
+});
+
+// attach cluster client for cross-cluster utilities
+client.cluster = new ClusterClient(client);
+
 client.loadCommands("src/commands");
 client.loadContexts("src/contexts");
 client.loadEvents("src/events");
+
+// shard lifecycle logs
+client.on("shardReady", (id, unavailableGuilds) => {
+  client.logger.success(`Shard ${id} ready${unavailableGuilds ? ` (${unavailableGuilds} unavailable)` : ""}`);
+});
+client.on("shardDisconnect", (event, id) => {
+  client.logger.warn(`Shard ${id} disconnected (${event?.code || "unknown"})`);
+});
+client.on("shardReconnecting", (id) => client.logger.log(`Shard ${id} reconnecting...`));
+client.on("shardResume", (id, replayed) => client.logger.success(`Shard ${id} resumed, replayed ${replayed} events`));
+client.on("shardError", (error, id) => client.logger.error(`Shard ${id} error`, error));
 
 // find unhandled promise rejections
 process.on("unhandledRejection", (err) => client.logger.error(`Unhandled exception`, err));

--- a/cluster.js
+++ b/cluster.js
@@ -1,0 +1,33 @@
+require("dotenv").config();
+require("module-alias/register");
+
+const { ClusterManager } = require("discord-hybrid-sharding");
+const path = require("path");
+const Logger = require("@helpers/Logger");
+
+const manager = new ClusterManager(path.join(__dirname, "bot.js"), {
+  totalShards: "auto",
+  shardsPerClusters: 2,
+  mode: "process",
+  token: process.env.BOT_TOKEN,
+});
+
+manager.on("clusterCreate", (cluster) => {
+  // Basic lifecycle logs in unified format
+  Logger.log(`[ClusterManager] Launched Cluster ${cluster.id}`);
+
+  cluster.on("death", (p) => {
+    Logger.warn(`[Cluster ${cluster.id}] process died with code ${p.exitCode}`);
+  });
+
+  cluster.on("message", (msg) => {
+    if (typeof msg === "string") {
+      Logger.log(`[Cluster ${cluster.id}] ${msg}`);
+    }
+  });
+});
+
+Logger.log("Spawning clusters...");
+manager.spawn({ timeout: -1 });
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "connect-mongo": "^5.1.0",
         "country-emoji-languages": "^1.0.1",
         "discord-giveaways": "^6.0.1",
+        "discord-hybrid-sharding": "^2.2.5",
         "discord-together": "^1.3.31",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.7",
@@ -2513,6 +2514,12 @@
       "peerDependencies": {
         "discord.js": ">=14.0.0"
       }
+    },
+    "node_modules/discord-hybrid-sharding": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/discord-hybrid-sharding/-/discord-hybrid-sharding-2.2.5.tgz",
+      "integrity": "sha512-XMScPJIaPGuze5RAKmIydZFi3MV0vRTJhHLP+ww+VGgTf/pKRuCpJYYa7CRcnuyH/0qOmDByZscJRiWJmLINMQ==",
+      "license": "MIT"
     },
     "node_modules/discord-together": {
       "version": "1.3.31",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "dev": "nodemon .",
-    "start": "node .",
+    "dev": "nodemon cluster.js",
+    "start": "node cluster.js",
     "format": "prettier --write src",
     "docker:package": "tar -cf discord-js-bot.tar dashboard logs src bot.js config.js dockerfile package.json package-lock.json",
     "docker:build": "docker build -t saitejamadha/discord-js-bot:5.6.0 ."
@@ -33,6 +33,7 @@
     "connect-mongo": "^5.1.0",
     "country-emoji-languages": "^1.0.1",
     "discord-giveaways": "^6.0.1",
+    "discord-hybrid-sharding": "^2.2.5",
     "discord-together": "^1.3.31",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.7",

--- a/src/structures/BotClient.js
+++ b/src/structures/BotClient.js
@@ -18,8 +18,8 @@ const giveawaysHandler = require("../handlers/giveaway");
 const { DiscordTogether } = require("discord-together");
 
 module.exports = class BotClient extends Client {
-  constructor() {
-    super({
+  constructor(externalOptions = {}) {
+    const defaultOptions = {
       intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
@@ -35,7 +35,10 @@ module.exports = class BotClient extends Client {
         repliedUser: false,
       },
       restRequestTimeout: 20000,
-    });
+    };
+
+    // Merge defaults with external options (e.g., shards, shardCount)
+    super({ ...defaultOptions, ...externalOptions });
 
     this.wait = require("util").promisify(setTimeout); // await client.wait(1000) - Wait 1 second
     this.config = require("@root/config"); // load the config file


### PR DESCRIPTION
Integrates discord-hybrid-sharding for cluster and shard management. Adds a new cluster.js entry point to manage clusters, updates bot.js to initialize the client with shard information, and enhances logging for shard lifecycle events. Updates BotClient to accept external options for sharding, and modifies package scripts to use cluster.js. Adds discord-hybrid-sharding as a dependency.